### PR TITLE
Log QUIC application handshake failure separately and don't treat it as error.

### DIFF
--- a/src/ping_clients/ping_client.rs
+++ b/src/ping_clients/ping_client.rs
@@ -7,7 +7,7 @@ pub struct PingClientPingResultDetails {
     pub actual_local_addr: Option<SocketAddr>,
     pub round_trip_time: Duration,
     pub is_timeout: bool,
-    pub warning: Option<Box<dyn std::error::Error + Send>>,
+    pub handshake_error: Option<Box<dyn std::error::Error + Send>>,
 }
 
 impl PingClientPingResultDetails {
@@ -15,13 +15,13 @@ impl PingClientPingResultDetails {
         actual_local_addr: Option<SocketAddr>,
         round_trip_time: Duration,
         is_timeout: bool,
-        warning: Option<Box<dyn std::error::Error + Send>>,
+        handshake_error: Option<Box<dyn std::error::Error + Send>>,
     ) -> PingClientPingResultDetails {
         PingClientPingResultDetails {
             actual_local_addr,
             round_trip_time,
             is_timeout,
-            warning,
+            handshake_error,
         }
     }
 }

--- a/src/ping_clients/ping_client.rs
+++ b/src/ping_clients/ping_client.rs
@@ -7,6 +7,7 @@ pub struct PingClientPingResultDetails {
     pub actual_local_addr: Option<SocketAddr>,
     pub round_trip_time: Duration,
     pub is_timeout: bool,
+    pub warning: Option<Box<dyn std::error::Error + Send>>,
 }
 
 impl PingClientPingResultDetails {
@@ -14,11 +15,13 @@ impl PingClientPingResultDetails {
         actual_local_addr: Option<SocketAddr>,
         round_trip_time: Duration,
         is_timeout: bool,
+        warning: Option<Box<dyn std::error::Error + Send>>,
     ) -> PingClientPingResultDetails {
         PingClientPingResultDetails {
             actual_local_addr,
             round_trip_time,
             is_timeout,
+            warning,
         }
     }
 }

--- a/src/ping_clients/ping_client_quic.rs
+++ b/src/ping_clients/ping_client_quic.rs
@@ -84,6 +84,9 @@ impl PingClientQuic {
         let connecting_result = connecting.await;
         let rtt = Instant::now().duration_since(start_time);
 
+        // If a QUIC connection returned errors other than timed out or local error, it means the local endpoint has successfully
+        // received packets from remote server, which means the underlying network is reachable, but higher level of stack went
+        // wrong, such as ALPN, so here, we should log this failure as warning instead.
         let connection = match connecting_result {
             Ok(connection) => Ok(connection),
             Err(e) => match e {

--- a/src/ping_clients/ping_client_quic.rs
+++ b/src/ping_clients/ping_client_quic.rs
@@ -92,20 +92,14 @@ impl PingClientQuic {
             Err(e) => match e {
                 ConnectionError::TimedOut => Err(PingClientError::PingFailed(Box::new(e))),
                 ConnectionError::LocallyClosed => Err(PingClientError::PingFailed(Box::new(e))),
-                _ => return Ok(PingClientPingResultDetails::new(None, rtt, false, Some(Box::new(e)))),
+                _ => {
+                    return Ok(PingClientPingResultDetails::new(None, rtt, false, Some(Box::new(e))))
+                },
             }
         }?;
 
-        let local_ip = connection.connection.local_ip();
-        return match local_ip {
-            Some(addr) => Ok(PingClientPingResultDetails::new(
-                Some(SocketAddr::new(addr, source.port())),
-                rtt,
-                false,
-                None,
-            )),
-            None => Ok(PingClientPingResultDetails::new(None, rtt, false, None)),
-        };
+        let local_ip = connection.connection.local_ip().map_or(None, |addr| Some(SocketAddr::new(addr, source.port())));
+        return Ok(PingClientPingResultDetails::new(local_ip, rtt, false, None));
     }
 }
 

--- a/src/ping_clients/ping_client_tcp.rs
+++ b/src/ping_clients/ping_client_tcp.rs
@@ -27,7 +27,7 @@ impl PingClientTcp {
         match connect_result {
             // Timeout is an expected value instead of an actual failure, so here we should return Ok.
             Err(e) if e.kind() == io::ErrorKind::TimedOut => {
-                return Ok(PingClientPingResultDetails::new(None, rtt, true))
+                return Ok(PingClientPingResultDetails::new(None, rtt, true, None))
             }
             Err(e) => return Err(PingClientError::PingFailed(Box::new(e))),
             Ok(()) => (),
@@ -37,8 +37,8 @@ impl PingClientTcp {
         // The worse case we can get is to output a 0.0.0.0 as source IP, which is not critical to what we are trying to do.
         let local_addr = socket.local_addr();
         return match local_addr {
-            Ok(addr) => Ok(PingClientPingResultDetails::new(Some(addr.as_socket().unwrap()), rtt, false)),
-            Err(_) => Ok(PingClientPingResultDetails::new(None, rtt, false)),
+            Ok(addr) => Ok(PingClientPingResultDetails::new(Some(addr.as_socket().unwrap()), rtt, false, None)),
+            Err(_) => Ok(PingClientPingResultDetails::new(None, rtt, false, None)),
         };
     }
 

--- a/src/ping_result.rs
+++ b/src/ping_result.rs
@@ -330,11 +330,11 @@ mod tests {
                 false,
                 Duration::from_millis(20),
                 false,
+                None,
                 Some(Box::new(io::Error::new(
                     io::ErrorKind::ConnectionAborted,
                     "connect aborted",
                 ))),
-                None,
             ),
             PingResult::new(
                 &Utc.ymd(2021, 7, 6).and_hms_milli(9, 10, 11, 12),
@@ -345,11 +345,11 @@ mod tests {
                 false,
                 Duration::from_millis(0),
                 false,
-                None,
                 Some(PingFailed(Box::new(io::Error::new(
                     io::ErrorKind::ConnectionRefused,
                     "connect failed",
                 )))),
+                None,
             ),
             PingResult::new(
                 &Utc.ymd(2021, 7, 6).and_hms_milli(9, 10, 11, 12),
@@ -360,11 +360,11 @@ mod tests {
                 false,
                 Duration::from_millis(0),
                 false,
-                None,
                 Some(PreparationFailed(Box::new(io::Error::new(
                     io::ErrorKind::AddrInUse,
                     "address in use",
                 )))),
+                None,
             ),
         ]
     }

--- a/src/ping_result.rs
+++ b/src/ping_result.rs
@@ -241,6 +241,7 @@ mod tests {
             vec![
                 "Reaching TCP 1.2.3.4:443 from 5.6.7.8:8080 (warmup) succeeded: RTT=10.00ms",
                 "Reaching TCP 1.2.3.4:443 from 5.6.7.8:8080 failed: Timed out, RTT = 1000.00ms",
+                "Reaching TCP 1.2.3.4:443 from 5.6.7.8:8080 succeeded with warning: RTT=20.00ms, Warning = connect aborted",
                 "Reaching TCP 1.2.3.4:443 from 5.6.7.8:8080 failed: connect failed",
                 "Unable to perform ping to TCP 1.2.3.4:443 from 5.6.7.8:8080, because failed preparing to ping: Error = address in use",
             ],
@@ -306,6 +307,21 @@ mod tests {
                 Duration::from_millis(1000),
                 true,
                 None,
+                None,
+            ),
+            PingResult::new(
+                &Utc.ymd(2021, 7, 6).and_hms_milli(9, 10, 11, 12),
+                1,
+                "TCP",
+                "1.2.3.4:443".parse().unwrap(),
+                "5.6.7.8:8080".parse().unwrap(),
+                false,
+                Duration::from_millis(20),
+                true,
+                Some(Box::new(io::Error::new(
+                    io::ErrorKind::ConnectionAborted,
+                    "connect aborted",
+                ))),
                 None,
             ),
             PingResult::new(

--- a/src/ping_result_processors/ping_result_processor_csv_logger.rs
+++ b/src/ping_result_processors/ping_result_processor_csv_logger.rs
@@ -29,7 +29,7 @@ impl PingResultProcessor for PingResultProcessorCsvLogger {
     fn initialize(&mut self) {
         // Writer CSV header
         self.log_file
-            .write("UTCTime,WorkerId,Protocol,TargetIP,TargetPort,SourceIP,SourcePort,IsWarmup,RTTInMs,IsTimedOut,PreparationError,PingError\n".as_bytes())
+            .write("UTCTime,WorkerId,Protocol,TargetIP,TargetPort,SourceIP,SourcePort,IsWarmup,RTTInMs,IsTimedOut,PingWarning,PreparationError,PingError\n".as_bytes())
             .expect(&format!(
                 "Failed to write logs to csv file! Path = {}",
                 self.log_path.display()

--- a/src/ping_result_processors/ping_result_processor_latency_bucket_logger.rs
+++ b/src/ping_result_processors/ping_result_processor_latency_bucket_logger.rs
@@ -148,13 +148,13 @@ mod tests {
                 "1.2.3.4:443".parse().unwrap(),
                 "5.6.7.8:8080".parse().unwrap(),
                 false,
-                Duration::from_millis(0),
+                Duration::from_millis(20),
                 false,
                 None,
-                Some(PingFailed(Box::new(io::Error::new(
-                    io::ErrorKind::ConnectionRefused,
-                    "connect failed",
-                )))),
+                Some(Box::new(io::Error::new(
+                    io::ErrorKind::ConnectionAborted,
+                    "connect aborted",
+                ))),
             ),
             PingResult::new(
                 &Utc.ymd(2021, 7, 6).and_hms_milli(9, 10, 11, 12),
@@ -165,11 +165,26 @@ mod tests {
                 false,
                 Duration::from_millis(0),
                 false,
+                Some(PingFailed(Box::new(io::Error::new(
+                    io::ErrorKind::ConnectionRefused,
+                    "connect failed",
+                )))),
                 None,
+            ),
+            PingResult::new(
+                &Utc.ymd(2021, 7, 6).and_hms_milli(9, 10, 11, 12),
+                1,
+                "TCP",
+                "1.2.3.4:443".parse().unwrap(),
+                "5.6.7.8:8080".parse().unwrap(),
+                false,
+                Duration::from_millis(0),
+                false,
                 Some(PreparationFailed(Box::new(io::Error::new(
                     io::ErrorKind::AddrInUse,
                     "address in use",
                 )))),
+                None,
             ),
         ];
 
@@ -179,7 +194,7 @@ mod tests {
             .iter()
             .for_each(|x| logger.update_statistics(x));
 
-        assert_eq!(3, logger.total_hit_count);
+        assert_eq!(4, logger.total_hit_count);
         assert_eq!(1, logger.timed_out_hit_count);
         assert_eq!(1, logger.failed_hit_count);
     }

--- a/src/ping_result_processors/ping_result_processor_latency_bucket_logger.rs
+++ b/src/ping_result_processors/ping_result_processor_latency_bucket_logger.rs
@@ -127,6 +127,7 @@ mod tests {
                 Duration::from_millis(10),
                 false,
                 None,
+                None,
             ),
             PingResult::new(
                 &Utc.ymd(2021, 7, 6).and_hms_milli(9, 10, 11, 12),
@@ -138,6 +139,7 @@ mod tests {
                 Duration::from_millis(1000),
                 true,
                 None,
+                None,
             ),
             PingResult::new(
                 &Utc.ymd(2021, 7, 6).and_hms_milli(9, 10, 11, 12),
@@ -148,6 +150,7 @@ mod tests {
                 false,
                 Duration::from_millis(0),
                 false,
+                None,
                 Some(PingFailed(Box::new(io::Error::new(
                     io::ErrorKind::ConnectionRefused,
                     "connect failed",
@@ -162,6 +165,7 @@ mod tests {
                 false,
                 Duration::from_millis(0),
                 false,
+                None,
                 Some(PreparationFailed(Box::new(io::Error::new(
                     io::ErrorKind::AddrInUse,
                     "address in use",

--- a/src/ping_worker.rs
+++ b/src/ping_worker.rs
@@ -112,6 +112,7 @@ impl PingWorker {
             self.is_warmup_worker,
             ping_result.round_trip_time,
             ping_result.is_timeout,
+            ping_result.warning,
             None,
         );
 
@@ -136,6 +137,7 @@ impl PingWorker {
             self.is_warmup_worker,
             Duration::from_millis(0),
             false,
+            None,
             Some(error),
         );
 

--- a/src/ping_worker.rs
+++ b/src/ping_worker.rs
@@ -112,8 +112,8 @@ impl PingWorker {
             self.is_warmup_worker,
             ping_result.round_trip_time,
             ping_result.is_timeout,
-            ping_result.warning,
             None,
+            ping_result.handshake_error,
         );
 
         self.result_sender.send(result).await.unwrap();
@@ -137,8 +137,8 @@ impl PingWorker {
             self.is_warmup_worker,
             Duration::from_millis(0),
             false,
-            None,
             Some(error),
+            None,
         );
 
         self.result_sender.send(result).await.unwrap();


### PR DESCRIPTION
This is because the remote endpoint can be reached from network perspective.