### PR TITLE
Use the estimated RTT from QUIC as the final RTT by default.

### DIFF
--- a/src/bin/rnp/rnp_cli_options.rs
+++ b/src/bin/rnp/rnp_cli_options.rs
@@ -82,8 +82,8 @@ pub struct RnpCliOptions {
     #[structopt(long = "alpn", default_value = "h3-29", help = "ALPN protocol used in QUIC. Specify \"none\" to disable ALPN.\nIt is usually h3-<ver> for http/3 or hq-<ver> for specific version of QUIC.\nFor latest IDs, please check here: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids")]
     pub alpn_protocol: String,
 
-    #[structopt(long, help = "Use the estimated RTT from QUIC connection as the RTT.")]
-    pub use_quic_rtt: bool,
+    #[structopt(long, help = "Calculate the RTT by checking the time of before and after doing QUIC connect instead of estimated RTT from QUIC. Not recommended, as this might cause the RTT time to be larger than the real one.")]
+    pub use_timer_rtt: bool,
 
     #[structopt(
         short = "q",
@@ -215,7 +215,7 @@ impl RnpCliOptions {
                     } else {
                         None
                     },
-                    use_quic_rtt: self.use_quic_rtt,
+                    use_timer_rtt: self.use_timer_rtt,
                 },
             },
             worker_scheduler_config: PingWorkerSchedulerConfig {
@@ -277,7 +277,7 @@ mod tests {
                 server_name: None,
                 log_tls_key: false,
                 alpn_protocol: String::from("h3-29"),
-                use_quic_rtt: false,
+                use_timer_rtt: false,
                 no_console_log: false,
                 csv_log_path: None,
                 json_log_path: None,
@@ -311,7 +311,7 @@ mod tests {
                 server_name: None,
                 log_tls_key: false,
                 alpn_protocol: String::from("h3-29"),
-                use_quic_rtt: false,
+                use_timer_rtt: false,
                 no_console_log: true,
                 csv_log_path: None,
                 json_log_path: None,
@@ -366,7 +366,7 @@ mod tests {
                 server_name: Some(String::from("localhost")),
                 log_tls_key: true,
                 alpn_protocol: String::from("hq-29"),
-                use_quic_rtt: true,
+                use_timer_rtt: true,
                 no_console_log: true,
                 csv_log_path: Some(PathBuf::from("log.csv")),
                 json_log_path: Some(PathBuf::from("log.json")),
@@ -406,7 +406,7 @@ mod tests {
                 "--log-tls-key",
                 "--alpn",
                 "hq-29",
-                "--use-quic-rtt",
+                "--use-timer-rtt",
                 "--no-console-log",
                 "--log-csv",
                 "log.csv",
@@ -438,7 +438,7 @@ mod tests {
                         server_name: None,
                         log_tls_key: false,
                         alpn_protocol: None,
-                        use_quic_rtt: false,
+                        use_timer_rtt: false,
                     },
                 },
                 worker_scheduler_config: PingWorkerSchedulerConfig {
@@ -477,7 +477,7 @@ mod tests {
                 server_name: None,
                 log_tls_key: false,
                 alpn_protocol: String::from("none"),
-                use_quic_rtt: false,
+                use_timer_rtt: false,
                 no_console_log: false,
                 csv_log_path: None,
                 json_log_path: None,
@@ -503,7 +503,7 @@ mod tests {
                         server_name: Some(String::from("localhost")),
                         log_tls_key: true,
                         alpn_protocol: Some(String::from("h3")),
-                        use_quic_rtt: true,
+                        use_timer_rtt: true,
                     },
                 },
                 worker_scheduler_config: PingWorkerSchedulerConfig {
@@ -542,7 +542,7 @@ mod tests {
                 server_name: Some(String::from("localhost")),
                 log_tls_key: true,
                 alpn_protocol: String::from("h3"),
-                use_quic_rtt: true,
+                use_timer_rtt: true,
                 no_console_log: true,
                 csv_log_path: Some(PathBuf::from("log.csv")),
                 json_log_path: Some(PathBuf::from("log.json")),

--- a/src/bin/rnp/rnp_cli_options.rs
+++ b/src/bin/rnp/rnp_cli_options.rs
@@ -82,6 +82,9 @@ pub struct RnpCliOptions {
     #[structopt(long = "alpn", default_value = "h3-29", help = "ALPN protocol used in QUIC. Specify \"none\" to disable ALPN.\nIt is usually h3-<ver> for http/3 or hq-<ver> for specific version of QUIC.\nFor latest IDs, please check here: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids")]
     pub alpn_protocol: String,
 
+    #[structopt(long, help = "Use the estimated RTT from QUIC connection as the RTT.")]
+    pub use_quic_rtt: bool,
+
     #[structopt(
         short = "q",
         long,
@@ -212,6 +215,7 @@ impl RnpCliOptions {
                     } else {
                         None
                     },
+                    use_quic_rtt: self.use_quic_rtt,
                 },
             },
             worker_scheduler_config: PingWorkerSchedulerConfig {
@@ -273,6 +277,7 @@ mod tests {
                 server_name: None,
                 log_tls_key: false,
                 alpn_protocol: String::from("h3-29"),
+                use_quic_rtt: false,
                 no_console_log: false,
                 csv_log_path: None,
                 json_log_path: None,
@@ -306,6 +311,7 @@ mod tests {
                 server_name: None,
                 log_tls_key: false,
                 alpn_protocol: String::from("h3-29"),
+                use_quic_rtt: false,
                 no_console_log: true,
                 csv_log_path: None,
                 json_log_path: None,
@@ -360,6 +366,7 @@ mod tests {
                 server_name: Some(String::from("localhost")),
                 log_tls_key: true,
                 alpn_protocol: String::from("hq-29"),
+                use_quic_rtt: true,
                 no_console_log: true,
                 csv_log_path: Some(PathBuf::from("log.csv")),
                 json_log_path: Some(PathBuf::from("log.json")),
@@ -399,6 +406,7 @@ mod tests {
                 "--log-tls-key",
                 "--alpn",
                 "hq-29",
+                "--use-quic-rtt",
                 "--no-console-log",
                 "--log-csv",
                 "log.csv",
@@ -429,7 +437,8 @@ mod tests {
                         use_fin_in_tcp_ping: false,
                         server_name: None,
                         log_tls_key: false,
-                        alpn_protocol: None
+                        alpn_protocol: None,
+                        use_quic_rtt: false,
                     },
                 },
                 worker_scheduler_config: PingWorkerSchedulerConfig {
@@ -468,6 +477,7 @@ mod tests {
                 server_name: None,
                 log_tls_key: false,
                 alpn_protocol: String::from("none"),
+                use_quic_rtt: false,
                 no_console_log: false,
                 csv_log_path: None,
                 json_log_path: None,
@@ -493,6 +503,7 @@ mod tests {
                         server_name: Some(String::from("localhost")),
                         log_tls_key: true,
                         alpn_protocol: Some(String::from("h3")),
+                        use_quic_rtt: true,
                     },
                 },
                 worker_scheduler_config: PingWorkerSchedulerConfig {
@@ -531,6 +542,7 @@ mod tests {
                 server_name: Some(String::from("localhost")),
                 log_tls_key: true,
                 alpn_protocol: String::from("h3"),
+                use_quic_rtt: true,
                 no_console_log: true,
                 csv_log_path: Some(PathBuf::from("log.csv")),
                 json_log_path: Some(PathBuf::from("log.json")),

--- a/src/ping_clients/ping_client_factory.rs
+++ b/src/ping_clients/ping_client_factory.rs
@@ -41,7 +41,7 @@ mod tests {
             server_name: None,
             log_tls_key: false,
             alpn_protocol: None,
-            use_quic_rtt: false,
+            use_timer_rtt: false,
         };
 
         let ping_client = new(RnpSupportedProtocol::TCP, &config);

--- a/src/ping_clients/ping_client_factory.rs
+++ b/src/ping_clients/ping_client_factory.rs
@@ -40,7 +40,8 @@ mod tests {
             use_fin_in_tcp_ping: false,
             server_name: None,
             log_tls_key: false,
-            alpn_protocol: None
+            alpn_protocol: None,
+            use_quic_rtt: false,
         };
 
         let ping_client = new(RnpSupportedProtocol::TCP, &config);

--- a/src/ping_clients/ping_client_quic.rs
+++ b/src/ping_clients/ping_client_quic.rs
@@ -30,9 +30,9 @@ impl PingClientQuic {
             .create_local_endpoint(source)
             .map_err(|e| PingClientError::PreparationFailed(Box::new(e)))?;
         let server_name = self.config.server_name.as_ref().map_or("", |s| &s);
-        let use_quic_rtt = self.config.use_quic_rtt;
+        let use_timer_rtt = self.config.use_timer_rtt;
         let ping_result =
-            PingClientQuic::connect_to_target(&endpoint, source, target, server_name, use_quic_rtt).await;
+            PingClientQuic::connect_to_target(&endpoint, source, target, server_name, use_timer_rtt).await;
         endpoint.wait_idle().await;
         return ping_result;
     }
@@ -76,7 +76,7 @@ impl PingClientQuic {
         source: &SocketAddr,
         target: &SocketAddr,
         server_name: &str,
-        use_quic_rtt: bool,
+        use_timer_rtt: bool,
     ) -> PingClientResult<PingClientPingResultDetails> {
         let start_time = Instant::now();
 
@@ -101,7 +101,7 @@ impl PingClientQuic {
         }?;
 
         let local_ip = connection.connection.local_ip().map_or(None, |addr| Some(SocketAddr::new(addr, source.port())));
-        if use_quic_rtt {
+        if !use_timer_rtt {
             rtt = connection.connection.rtt();
         }
         return Ok(PingClientPingResultDetails::new(local_ip, rtt, false, None));

--- a/src/ping_clients/ping_client_quic.rs
+++ b/src/ping_clients/ping_client_quic.rs
@@ -30,8 +30,9 @@ impl PingClientQuic {
             .create_local_endpoint(source)
             .map_err(|e| PingClientError::PreparationFailed(Box::new(e)))?;
         let server_name = self.config.server_name.as_ref().map_or("", |s| &s);
+        let use_quic_rtt = self.config.use_quic_rtt;
         let ping_result =
-            PingClientQuic::connect_to_target(&endpoint, source, target, server_name).await;
+            PingClientQuic::connect_to_target(&endpoint, source, target, server_name, use_quic_rtt).await;
         endpoint.wait_idle().await;
         return ping_result;
     }
@@ -75,6 +76,7 @@ impl PingClientQuic {
         source: &SocketAddr,
         target: &SocketAddr,
         server_name: &str,
+        use_quic_rtt: bool,
     ) -> PingClientResult<PingClientPingResultDetails> {
         let start_time = Instant::now();
 
@@ -82,7 +84,7 @@ impl PingClientQuic {
             .connect(target, &server_name)
             .map_err(|e| PingClientError::PingFailed(Box::new(e)))?;
         let connecting_result = connecting.await;
-        let rtt = Instant::now().duration_since(start_time);
+        let mut rtt = Instant::now().duration_since(start_time);
 
         // If a QUIC connection returned errors other than timed out or local error, it means the local endpoint has successfully
         // received packets from remote server, which means the underlying network is reachable, but higher level of stack went
@@ -99,6 +101,9 @@ impl PingClientQuic {
         }?;
 
         let local_ip = connection.connection.local_ip().map_or(None, |addr| Some(SocketAddr::new(addr, source.port())));
+        if use_quic_rtt {
+            rtt = connection.connection.rtt();
+        }
         return Ok(PingClientPingResultDetails::new(local_ip, rtt, false, None));
     }
 }

--- a/src/ping_clients/ping_client_tcp.rs
+++ b/src/ping_clients/ping_client_tcp.rs
@@ -102,7 +102,7 @@ mod tests {
                 server_name: None,
                 log_tls_key: false,
                 alpn_protocol: None,
-                use_quic_rtt: false,
+                use_timer_rtt: false,
             };
             let mut ping_client = ping_client_factory::new(RnpSupportedProtocol::TCP, &config);
 

--- a/src/ping_clients/ping_client_tcp.rs
+++ b/src/ping_clients/ping_client_tcp.rs
@@ -101,7 +101,8 @@ mod tests {
                 use_fin_in_tcp_ping: false,
                 server_name: None,
                 log_tls_key: false,
-                alpn_protocol: None
+                alpn_protocol: None,
+                use_quic_rtt: false,
             };
             let mut ping_client = ping_client_factory::new(RnpSupportedProtocol::TCP, &config);
 

--- a/src/rnp_core_config.rs
+++ b/src/rnp_core_config.rs
@@ -55,7 +55,7 @@ pub struct PingClientConfig {
     pub server_name: Option<String>,
     pub log_tls_key: bool,
     pub alpn_protocol: Option<String>,
-    pub use_quic_rtt: bool,
+    pub use_timer_rtt: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/rnp_core_config.rs
+++ b/src/rnp_core_config.rs
@@ -55,6 +55,7 @@ pub struct PingClientConfig {
     pub server_name: Option<String>,
     pub log_tls_key: bool,
     pub alpn_protocol: Option<String>,
+    pub use_quic_rtt: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
This will make the RTT to be more accurate.